### PR TITLE
fix/PLF-8655: Kudos administration page fails to be created when exo-…

### DIFF
--- a/kudos-webapps/src/main/webapp/WEB-INF/conf/kudos/portal/group/platform/administrators/navigation.xml
+++ b/kudos-webapps/src/main/webapp/WEB-INF/conf/kudos/portal/group/platform/administrators/navigation.xml
@@ -30,7 +30,6 @@
         <node>
             <name>rewardAdministration</name>
             <label>Reward</label>
-            <page-reference>group::/platform/rewarding::rewardAdministration</page-reference>
             <node>
                 <name>kudosAdministration</name>
                 <label>Kudos</label>


### PR DESCRIPTION
The Kudos administration page fails to be created when exo-wallet is not installed.
This is due to the rewards administration page being referenced in the kudos navigation configuration.
We should move it from navigation.xml